### PR TITLE
Add a way to set a static tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ func main() {
 
 Some logrus fields have a special meaning in this hook.
 
-- `tag` is used as a fluentd tag. (if `tag` is omitted, Entry.Message is used as a fluentd tag)
+- `tag` is used as a fluentd tag. (if `tag` is omitted, Entry.Message is used as a fluentd tag, unless a static tag is set for the hook with `hook.SetTag`)

--- a/fluent.go
+++ b/fluent.go
@@ -23,6 +23,7 @@ type fluentHook struct {
 	host   string
 	port   int
 	levels []logrus.Level
+	tag    *string
 }
 
 func NewHook(host string, port int) *fluentHook {
@@ -30,6 +31,7 @@ func NewHook(host string, port int) *fluentHook {
 		host:   host,
 		port:   port,
 		levels: defaultLevels,
+		tag:    nil,
 	}
 }
 
@@ -75,9 +77,14 @@ func (hook *fluentHook) Fire(entry *logrus.Entry) error {
 	}
 
 	setLevelString(entry, data)
-	tag := getTagAndDel(entry, data)
-	if tag != entry.Message {
-		setMessage(entry, data)
+	var tag string
+	if hook.tag == nil {
+		tag = getTagAndDel(entry, data)
+		if tag != entry.Message {
+			setMessage(entry, data)
+		}
+	} else {
+		tag = *hook.tag
 	}
 
 	fluentData := ConvertToValue(data, TagName)
@@ -91,4 +98,12 @@ func (hook *fluentHook) Levels() []logrus.Level {
 
 func (hook *fluentHook) SetLevels(levels []logrus.Level) {
 	hook.levels = levels
+}
+
+func (hook *fluentHook) Tag() string {
+	return *hook.tag
+}
+
+func (hook *fluentHook) SetTag(tag string) {
+	hook.tag = &tag
 }

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -81,10 +81,38 @@ func TestLogEntryMessageReceived(t *testing.T) {
 	}
 }
 
+func TestLogEntryWithStaticTag(t *testing.T) {
+	f := logrus.Fields{
+		"tag":   "something",
+		"value": "data",
+	}
+	result := testLogWithStaticTag(t, f, "MyMessage5")
+
+	switch {
+	case !strings.Contains(result, "testing"):
+		t.Errorf("message did not contain the correct, static tag")
+	case !strings.Contains(result, "something"):
+		t.Errorf("message did not contain the tag field")
+	}
+}
+
 func testLog(t *testing.T, f logrus.Fields, message string) string {
 	data = make(chan string, 1)
 	port := startMockServer(t)
 	hook := NewHook(testHOST, port)
+	logger := logrus.New()
+	logger.Hooks.Add(hook)
+
+	logger.WithFields(f).Error(message)
+
+	return <-data
+}
+
+func testLogWithStaticTag(t *testing.T, f logrus.Fields, message string) string {
+	data = make(chan string, 1)
+	port := startMockServer(t)
+	hook := NewHook(testHOST, port)
+	hook.SetTag("testing")
 	logger := logrus.New()
 	logger.Hooks.Add(hook)
 


### PR DESCRIPTION
Adds the `hook.SetTag` function that makes it possible to pre-define a tag. This way a tag does not have to be included in every single message.

With this implementation, the static tag set on the hook overrides whatever may be in the message itself.
