### PR TITLE
Add persistent connection logger

### DIFF
--- a/fluent.go
+++ b/fluent.go
@@ -19,20 +19,106 @@ var defaultLevels = []logrus.Level{
 	logrus.InfoLevel,
 }
 
-type fluentHook struct {
+// FluentHook is logrus hook for fluentd.
+type FluentHook struct {
+	// Fluent is actual fluentd logger.
+	// If set, this logger is used for logging.
+	// otherwise new logger is created every time.
+	Fluent *fluent.Fluent
+
 	host   string
 	port   int
 	levels []logrus.Level
 	tag    *string
 }
 
-func NewHook(host string, port int) *fluentHook {
-	return &fluentHook{
+// New returns initialized logrus hook for fluentd with persistent fluentd logger.
+func New(host string, port int) (*FluentHook, error) {
+	fd, err := fluent.New(fluent.Config{FluentHost: host, FluentPort: port})
+	if err != nil {
+		return nil, err
+	}
+
+	return &FluentHook{
+		levels: defaultLevels,
+		Fluent: fd,
+	}, nil
+}
+
+// NewHook returns initialized logrus hook for fluentd.
+// (** deperecated: use New() **)
+func NewHook(host string, port int) *FluentHook {
+	return &FluentHook{
 		host:   host,
 		port:   port,
 		levels: defaultLevels,
 		tag:    nil,
 	}
+}
+
+// Levels returns logging level to fire this hook.
+func (hook *FluentHook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+// SetLevels sets logging level to fire this hook.
+func (hook *FluentHook) SetLevels(levels []logrus.Level) {
+	hook.levels = levels
+}
+
+// Tag returns custom static tag.
+func (hook *FluentHook) Tag() string {
+	if hook.tag == nil {
+		return ""
+	}
+
+	return *hook.tag
+}
+
+// SetTag sets custom static tag to override tag in the message fields.
+func (hook *FluentHook) SetTag(tag string) {
+	hook.tag = &tag
+}
+
+// Fire is invoked by logrus and sends log to fluentd logger.
+func (hook *FluentHook) Fire(entry *logrus.Entry) error {
+	var logger *fluent.Fluent
+	var err error
+
+	switch {
+	case hook.Fluent != nil:
+		logger = hook.Fluent
+	default:
+		logger, err = fluent.New(fluent.Config{
+			FluentHost: hook.host,
+			FluentPort: hook.port,
+		})
+		if err != nil {
+			return err
+		}
+		defer logger.Close()
+	}
+
+	// Create a map for passing to FluentD
+	data := make(logrus.Fields)
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+
+	setLevelString(entry, data)
+	var tag string
+	if hook.tag == nil {
+		tag = getTagAndDel(entry, data)
+		if tag != entry.Message {
+			setMessage(entry, data)
+		}
+	} else {
+		tag = *hook.tag
+	}
+
+	fluentData := ConvertToValue(data, TagName)
+	err = logger.PostWithTime(tag, entry.Time, fluentData)
+	return err
 }
 
 func getTagAndDel(entry *logrus.Entry, data logrus.Fields) string {
@@ -58,52 +144,4 @@ func setMessage(entry *logrus.Entry, data logrus.Fields) {
 	if _, ok := data[MessageField]; !ok {
 		data[MessageField] = entry.Message
 	}
-}
-
-func (hook *fluentHook) Fire(entry *logrus.Entry) error {
-	logger, err := fluent.New(fluent.Config{
-		FluentHost: hook.host,
-		FluentPort: hook.port,
-	})
-	if err != nil {
-		return err
-	}
-	defer logger.Close()
-
-	// Create a map for passing to FluentD
-	data := make(logrus.Fields)
-	for k, v := range entry.Data {
-		data[k] = v
-	}
-
-	setLevelString(entry, data)
-	var tag string
-	if hook.tag == nil {
-		tag = getTagAndDel(entry, data)
-		if tag != entry.Message {
-			setMessage(entry, data)
-		}
-	} else {
-		tag = *hook.tag
-	}
-
-	fluentData := ConvertToValue(data, TagName)
-	err = logger.PostWithTime(tag, entry.Time, fluentData)
-	return err
-}
-
-func (hook *fluentHook) Levels() []logrus.Level {
-	return hook.levels
-}
-
-func (hook *fluentHook) SetLevels(levels []logrus.Level) {
-	hook.levels = levels
-}
-
-func (hook *fluentHook) Tag() string {
-	return *hook.tag
-}
-
-func (hook *fluentHook) SetTag(tag string) {
-	hook.tag = &tag
 }

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -1,7 +1,9 @@
 package logrus_fluent
 
 import (
-	"bytes"
+	"bufio"
+	"fmt"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -9,61 +11,126 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
-var data chan string
-
-const (
-	testHOST = "localhost"
+var (
+	// used for persistent mock server
+	data     = make(chan string)
+	mockPort int
 )
 
-func TestLogEntryMessageReceivedWithTagAndMessage(t *testing.T) {
-	f := logrus.Fields{
-		"message": "message!",
-		"tag":     "debug.test",
-		"value":   "data",
-	}
-	result := testLog(t, f, "MyMessage1")
+const (
+	defaultLoopCount = 5 // assertion count
+	defaultStaticTag = "STATIC_TAG"
+	testHOST         = "localhost"
+)
 
+func TestNew(t *testing.T) {
+	_, port := newMockServer(t, nil)
+	hook, err := New(testHOST, port)
 	switch {
-	case !strings.Contains(result, "\x94\xaadebug.test\xd2"):
-		t.Errorf("message did not contain tag")
-	case !strings.Contains(result, "value\xa4data"):
-		t.Errorf("message did not contain value")
-	case !strings.Contains(result, "\xa7message\xa8message!"):
-		t.Errorf("message did not contain message")
+	case err != nil:
+		t.Errorf("error on New: %s", err.Error())
+	case hook == nil:
+		t.Errorf("hook should not be nil")
+	case len(hook.levels) != len(defaultLevels):
+		t.Errorf("hook.levels should be defaultLevels")
 	}
 }
 
-func TestLogEntryMessageReceivedWithMessage(t *testing.T) {
-	f := logrus.Fields{
-		"message": "message!",
-		"value":   "data",
-	}
-	result := testLog(t, f, "MyMessage2")
-
+func TestNewHook(t *testing.T) {
+	const testPort = -1
+	hook := NewHook(testHOST, testPort)
 	switch {
-	case !strings.Contains(result, "\xaaMyMessage2\xd2"):
-		t.Errorf("message did not contain tag from entry.Message")
-	case !strings.Contains(result, "value\xa4data"):
-		t.Errorf("message did not contain value")
-	case !strings.Contains(result, "\xa7message\xa8message!"):
-		t.Errorf("message did not contain message")
+	case hook == nil:
+		t.Errorf("hook should not be nil")
+	case hook.host != testHOST:
+		t.Errorf("hook.host should be %s, but %s", testHOST, hook.host)
+	case hook.port != testPort:
+		t.Errorf("hook.port should be %d, but %d", testPort, hook.port)
+	case len(hook.levels) != len(defaultLevels):
+		t.Errorf("hook.levels should be defaultLevels")
 	}
 }
 
-func TestLogEntryMessageReceivedWithTag(t *testing.T) {
-	f := logrus.Fields{
-		"tag":   "debug.test",
-		"value": "data",
-	}
-	result := testLog(t, f, "MyMessage3")
+func TestLevels(t *testing.T) {
+	hook := FluentHook{}
 
+	levels := hook.Levels()
+	if levels != nil {
+		t.Errorf("hook.Levels() should be nil, but %v", levels)
+	}
+
+	hook.levels = []logrus.Level{logrus.WarnLevel}
+	levels = hook.Levels()
 	switch {
-	case !strings.Contains(result, "\x94\xaadebug.test\xd2"):
-		t.Errorf("message did not contain tag")
-	case !strings.Contains(result, "value\xa4data"):
-		t.Errorf("message did not contain value")
-	case !strings.Contains(result, "\xa7message\xaaMyMessage3"):
-		t.Errorf("message did not contain entry.Message")
+	case levels == nil:
+		t.Errorf("hook.Levels() should not be nil")
+	case len(levels) != 1:
+		t.Errorf("hook.Levels() should have 1 length")
+	case levels[0] != logrus.WarnLevel:
+		t.Errorf("hook.Levels() should have logrus.WarnLevel")
+	}
+}
+
+func TestSetLevels(t *testing.T) {
+	hook := FluentHook{}
+
+	levels := hook.levels
+	if levels != nil {
+		t.Errorf("hook.levels should be nil, but %v", levels)
+	}
+
+	hook.SetLevels([]logrus.Level{logrus.WarnLevel})
+	levels = hook.levels
+	switch {
+	case levels == nil:
+		t.Errorf("hook.levels should not be nil")
+	case len(levels) != 1:
+		t.Errorf("hook.levels should have 1 length")
+	case levels[0] != logrus.WarnLevel:
+		t.Errorf("hook.levels should have logrus.WarnLevel")
+	}
+
+	hook.SetLevels(nil)
+	levels = hook.levels
+	if levels != nil {
+		t.Errorf("hook.levels should be nil, but %v", levels)
+	}
+}
+
+func TestTag(t *testing.T) {
+	hook := FluentHook{}
+
+	tag := hook.Tag()
+	if tag != "" {
+		t.Errorf("hook.Tag() should be empty, but %s", tag)
+	}
+
+	defaultTag := defaultStaticTag
+	hook.tag = &defaultTag
+	tag = hook.Tag()
+	switch {
+	case tag == "":
+		t.Errorf("hook.Tag() should not be empty")
+	case tag != defaultTag:
+		t.Errorf("hook.Tag() should be %s, but %s", defaultTag, tag)
+	}
+}
+
+func TestSetTag(t *testing.T) {
+	hook := FluentHook{}
+
+	tag := hook.tag
+	if tag != nil {
+		t.Errorf("hook.tag should be nil, but %s", *tag)
+	}
+
+	hook.SetTag(defaultStaticTag)
+	tag = hook.tag
+	switch {
+	case tag == nil:
+		t.Errorf("hook.tag should not be nil")
+	case *tag != defaultStaticTag:
+		t.Errorf("hook.tag should be %s, but %s", defaultStaticTag, *tag)
 	}
 }
 
@@ -71,14 +138,77 @@ func TestLogEntryMessageReceived(t *testing.T) {
 	f := logrus.Fields{
 		"value": "data",
 	}
-	result := testLog(t, f, "MyMessage4")
 
-	switch {
-	case !strings.Contains(result, "value\xa4data"):
-		t.Errorf("message did not contain value")
-	case !strings.Contains(result, "\xaaMyMessage4"):
-		t.Errorf("message did not contain entry.Message")
+	assertion := func(result string) {
+		switch {
+		case !strings.Contains(result, "value\xa4data"):
+			t.Errorf("message did not contain value")
+		case !strings.Contains(result, "\xaaMyMessage1"):
+			t.Errorf("message did not contain entry.Message")
+		}
 	}
+	assertLogHook(t, f, "MyMessage1", assertion)
+
+}
+
+func TestLogEntryMessageReceivedWithTag(t *testing.T) {
+	f := logrus.Fields{
+		"tag":   "debug.test",
+		"value": "data",
+	}
+
+	assertion := func(result string) {
+		switch {
+		case !strings.Contains(result, "\x94\xaadebug.test\xd2"):
+			t.Errorf("message did not contain tag")
+		case !strings.Contains(result, "value\xa4data"):
+			t.Errorf("message did not contain value")
+		case !strings.Contains(result, "\xa7message\xaaMyMessage2"):
+			t.Errorf("message did not contain entry.Message")
+		}
+	}
+	assertLogHook(t, f, "MyMessage2", assertion)
+}
+
+func TestLogEntryMessageReceivedWithMessage(t *testing.T) {
+	fmt.Printf("TestLogEntryMessageReceivedWithMessage...\n")
+
+	f := logrus.Fields{
+		"message": "message!",
+		"value":   "data",
+	}
+
+	assertion := func(result string) {
+		switch {
+		case !strings.Contains(result, "\xaaMyMessage3\xd2"):
+			t.Errorf("message did not contain tag from entry.Message")
+		case !strings.Contains(result, "value\xa4data"):
+			t.Errorf("message did not contain value")
+		case !strings.Contains(result, "\xa7message\xa8message!"):
+			t.Errorf("message did not contain message")
+		}
+	}
+	assertLogHook(t, f, "MyMessage3", assertion)
+}
+
+func TestLogEntryMessageReceivedWithTagAndMessage(t *testing.T) {
+	f := logrus.Fields{
+		"message": "message!",
+		"tag":     "debug.test",
+		"value":   "data",
+	}
+
+	assertion := func(result string) {
+		switch {
+		case !strings.Contains(result, "\x94\xaadebug.test\xd2"):
+			t.Errorf("message did not contain tag")
+		case !strings.Contains(result, "value\xa4data"):
+			t.Errorf("message did not contain value")
+		case !strings.Contains(result, "\xa7message\xa8message!"):
+			t.Errorf("message did not contain message")
+		}
+	}
+	assertLogHook(t, f, "MyMessage4", assertion)
 }
 
 func TestLogEntryWithStaticTag(t *testing.T) {
@@ -86,61 +216,107 @@ func TestLogEntryWithStaticTag(t *testing.T) {
 		"tag":   "something",
 		"value": "data",
 	}
-	result := testLogWithStaticTag(t, f, "MyMessage5")
 
-	switch {
-	case !strings.Contains(result, "testing"):
-		t.Errorf("message did not contain the correct, static tag")
-	case !strings.Contains(result, "something"):
-		t.Errorf("message did not contain the tag field")
+	assertion := func(result string) {
+		switch {
+		case !strings.Contains(result, defaultStaticTag):
+			t.Errorf("message did not contain the correct, static tag")
+		case !strings.Contains(result, "something"):
+			t.Errorf("message did not contain the tag field")
+		}
+	}
+	assertLogHookWithStaticTag(t, f, "MyMessage5", assertion)
+}
+
+func assertLogHook(t *testing.T, f logrus.Fields, message string, assertFunc func(string)) {
+	assertLogMessage(t, f, message, "", assertFunc)
+}
+
+func assertLogHookWithStaticTag(t *testing.T, f logrus.Fields, message string, assertFunc func(string)) {
+	assertLogMessage(t, f, message, defaultStaticTag, assertFunc)
+}
+
+func assertLogMessage(t *testing.T, f logrus.Fields, message string, tag string, assertFunc func(string)) {
+	// assert brand new logger
+	{
+		localData := make(chan string)
+		_, port := newMockServer(t, localData)
+		hook := NewHook(testHOST, port)
+		if tag != "" {
+			hook.SetTag(tag)
+		}
+		logger := logrus.New()
+		logger.Hooks.Add(hook)
+
+		for i := 0; i < defaultLoopCount; i++ {
+			logger.WithFields(f).Error(message)
+			assertFunc(<-localData)
+		}
+	}
+
+	// assert persistent logger
+	{
+		port := getOrCreateMockServer(t, data)
+		hook, err := New(testHOST, port)
+		if err != nil {
+			t.Errorf("Error on NewHookWithLogger: %s", err.Error())
+		}
+		if tag != "" {
+			hook.SetTag(tag)
+		}
+
+		logger := logrus.New()
+		logger.Hooks.Add(hook)
+
+		for i := 0; i < defaultLoopCount; i++ {
+			logger.WithFields(f).Error(message)
+			assertFunc(<-data)
+		}
 	}
 }
 
-func testLog(t *testing.T, f logrus.Fields, message string) string {
-	data = make(chan string, 1)
-	port := startMockServer(t)
-	hook := NewHook(testHOST, port)
-	logger := logrus.New()
-	logger.Hooks.Add(hook)
-
-	logger.WithFields(f).Error(message)
-
-	return <-data
+func getOrCreateMockServer(t *testing.T, data chan string) int {
+	if mockPort == 0 {
+		_, mockPort = newMockServer(t, data)
+	}
+	return mockPort
 }
 
-func testLogWithStaticTag(t *testing.T, f logrus.Fields, message string) string {
-	data = make(chan string, 1)
-	port := startMockServer(t)
-	hook := NewHook(testHOST, port)
-	hook.SetTag("testing")
-	logger := logrus.New()
-	logger.Hooks.Add(hook)
-
-	logger.WithFields(f).Error(message)
-
-	return <-data
-}
-
-func startMockServer(t *testing.T) int {
+func newMockServer(t *testing.T, data chan string) (net.Listener, int) {
 	l, err := net.Listen("tcp", testHOST+":0")
 	if err != nil {
 		t.Errorf("Error listening: %s", err.Error())
 	}
+
+	count := 0
 	go func() {
 		for {
+			count++
 			conn, err := l.Accept()
 			if err != nil {
 				t.Errorf("Error accepting: %s", err.Error())
 			}
-			go handleRequest(conn, l)
+
+			go handleRequest(conn, l, data)
+			if count == defaultLoopCount {
+				l.Close()
+				return
+			}
 		}
 	}()
-	return l.Addr().(*net.TCPAddr).Port
+	return l, l.Addr().(*net.TCPAddr).Port
 }
 
-func handleRequest(conn net.Conn, l net.Listener) {
-	bf := new(bytes.Buffer)
-	bf.ReadFrom(conn)
-	conn.Close()
-	data <- bf.String()
+func handleRequest(conn net.Conn, l net.Listener, data chan string) {
+	r := bufio.NewReader(conn)
+	for {
+		b := make([]byte, 1<<10) // Read 1KB at a time
+		_, err := r.Read(b)
+		if err == io.EOF {
+			continue
+		} else if err != nil {
+			fmt.Printf("Error reading from connection: %s", err)
+		}
+		data <- string(b)
+	}
 }


### PR DESCRIPTION
re-implement #3 and refactored testing for persistent connection.
- Add New() function to create hook with persistent fluentd logger
  - it could use same connection
- Change testing to check the message for both `New()` and `NewHook()`
- Change hook struct from unimported to imported
  - Allow user to customize fluentd logger
