### PR TITLE
Fix panic where struct contains embedded unexported struct

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -11,7 +11,7 @@ func ConvertToValue(p interface{}, tagName string) interface{} {
 	rv := toValue(p)
 	switch rv.Kind() {
 	case reflect.Struct:
-		return converFromStruct(rv.Interface(), tagName)
+		return convertFromStruct(rv.Interface(), tagName)
 	case reflect.Map:
 		return convertFromMap(rv, tagName)
 	case reflect.Slice:
@@ -42,22 +42,44 @@ func convertFromSlice(rv reflect.Value, tagName string) interface{} {
 	return result
 }
 
-// converFromStruct converts struct to value
+// convertFromStruct converts struct to value
 // see: https://github.com/fatih/structs/
-func converFromStruct(p interface{}, tagName string) interface{} {
+func convertFromStruct(p interface{}, tagName string) interface{} {
 	result := make(map[string]interface{})
-	t := toType(p)
-	values := toValue(p)
+	return convertFromStructDeep(result, tagName, toType(p), toValue(p))
+}
+
+func convertFromStructDeep(result map[string]interface{}, tagName string, t reflect.Type, values reflect.Value) interface{} {
 	for i, max := 0, t.NumField(); i < max; i++ {
 		f := t.Field(i)
 		if f.PkgPath != "" && !f.Anonymous {
-			continue // skip private field
+			continue
 		}
+
+		if f.Anonymous {
+			tt := f.Type
+			if tt.Kind() == reflect.Ptr {
+				tt = tt.Elem()
+			}
+			vv := values.Field(i)
+			if !vv.IsValid() {
+				continue
+			}
+			if vv.Kind() == reflect.Ptr {
+				vv = vv.Elem()
+			}
+			convertFromStructDeep(result, tagName, tt, vv)
+			continue
+		}
+
 		tag, opts := parseTag(f, tagName)
 		if tag == "-" {
 			continue // skip `-` tag
 		}
 
+		if !values.IsValid() {
+			continue
+		}
 		v := values.Field(i)
 		if opts.Has("omitempty") && isZero(v) {
 			continue // skip zero-value when omitempty option exists in tag

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -6,7 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type animal struct {
+	Fur    bool
+	skills string
+}
+
 type Creature struct {
+	*animal
 	Name   string
 	Human  bool
 	Height int
@@ -18,6 +24,10 @@ func TestConvertToValueStruct(t *testing.T) {
 	assert := assert.New(t)
 
 	v := Creature{
+		animal: &animal{
+			Fur:    true,
+			skills: "kill,purr",
+		},
 		Name:   "cat",
 		Height: 50,
 		Weight: 4,
@@ -32,6 +42,8 @@ func TestConvertToValueStruct(t *testing.T) {
 	assert.Equal(v.Weight, r["Weight"])
 	assert.Equal(v.Alias, r["nickname"])
 	assert.Equal(v.Human, r["Human"])
+	assert.Equal(v.Fur, r["Fur"])
+	assert.NotContains(r, "skills")
 }
 
 func TestConvertToValueSlice(t *testing.T) {


### PR DESCRIPTION
The issue comes from the fact that unexported struct-typed embedded fields were not handled separately leading to a panic when using `Interface()` function because of an unexported field.

Fix #14 