### PR TITLE
Fix panic when struct contains non-struct anonymous fields

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -68,7 +68,10 @@ func convertFromStructDeep(result map[string]interface{}, tagName string, t refl
 			if vv.Kind() == reflect.Ptr {
 				vv = vv.Elem()
 			}
-			convertFromStructDeep(result, tagName, tt, vv)
+
+			if vv.Kind() == reflect.Struct {
+				convertFromStructDeep(result, tagName, tt, vv)
+			}
 			continue
 		}
 

--- a/reflect_test.go
+++ b/reflect_test.go
@@ -6,7 +6,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type eyes int
+
 type animal struct {
+	eyes
+
 	Fur    bool
 	skills string
 }
@@ -18,6 +22,7 @@ type Creature struct {
 	Height int
 	Weight int
 	Alias  string `fluent:"nickname"`
+	Cute   bool   `fluent:"-"`
 }
 
 func TestConvertToValueStruct(t *testing.T) {
@@ -25,6 +30,7 @@ func TestConvertToValueStruct(t *testing.T) {
 
 	v := Creature{
 		animal: &animal{
+			eyes:   2,
 			Fur:    true,
 			skills: "kill,purr",
 		},
@@ -43,7 +49,9 @@ func TestConvertToValueStruct(t *testing.T) {
 	assert.Equal(v.Alias, r["nickname"])
 	assert.Equal(v.Human, r["Human"])
 	assert.Equal(v.Fur, r["Fur"])
+	assert.NotContains(r, "Cute")
 	assert.NotContains(r, "skills")
+	assert.NotContains(r, "eyes")
 }
 
 func TestConvertToValueSlice(t *testing.T) {


### PR DESCRIPTION
<details>

```
panic: reflect: NumField of non-struct type

goroutine 700 [running]:
testing.tRunner.func1(0xc4201520d0)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:622 +0x29d
panic(0x12a6ee0, 0xc42010c110)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
reflect.(*rtype).NumField(0x12a6620, 0x108f363)
	/usr/local/Cellar/go/1.8.1/libexec/src/reflect/type.go:1015 +0x89
github.com/evalphobia/logrus_fluent.convertFromStructDeep(0xc420168240, 0x1311515, 0x6, 0x1450800, 0x12a6620, 0x12a6620, 0xc4201106e0, 0x1c2, 0x0, 0x0)
	github.com/evalphobia/logrus_fluent/_test/_obj_test/reflect.go:65 +0x59
github.com/evalphobia/logrus_fluent.convertFromStructDeep(0xc420168240, 0x1311515, 0x6, 0x1450800, 0x12daca0, 0x12daca0, 0xc4201106e0, 0x199, 0x0, 0x0)
	github.com/evalphobia/logrus_fluent/_test/_obj_test/reflect.go:94 +0x2aa
github.com/evalphobia/logrus_fluent.convertFromStructDeep(0xc420168240, 0x1311515, 0x6, 0x1450800, 0x12edc80, 0x12edc80, 0xc4204aa1c0, 0x99, 0xc4204aa1c0, 0x99)
	github.com/evalphobia/logrus_fluent/_test/_obj_test/reflect.go:94 +0x2aa
github.com/evalphobia/logrus_fluent.convertFromStruct(0x12edc80, 0xc4204aa1c0, 0x1311515, 0x6, 0xc4204aa1c0, 0xc420494f58)
	github.com/evalphobia/logrus_fluent/_test/_obj_test/reflect.go:60 +0x104
github.com/evalphobia/logrus_fluent.ConvertToValue(0x12edc80, 0xc4204aa1c0, 0x1311515, 0x6, 0xc420144200, 0xc420494ef8)
	github.com/evalphobia/logrus_fluent/_test/_obj_test/reflect.go:15 +0x15d
github.com/evalphobia/logrus_fluent.TestConvertToValueStruct(0xc4201520d0)
	/Users/zirkome/work/src/github.com/evalphobia/logrus_fluent/reflect_test.go:40 +0x13e
testing.tRunner(0xc4201520d0, 0x13220a8)
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
	/usr/local/Cellar/go/1.8.1/libexec/src/testing/testing.go:697 +0x2ca
```
</details>

The panic occurred when a non-struct anonymous field is contained in anonymous struct field.
The PR also contains a test case for this particular issue.

/cc @evalphobia