### PR TITLE
customization of logrus.Level stringification

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	DefaultMessageField   string
 	DefaultIgnoreFields   map[string]struct{}
 	DefaultFilters        map[string]func(interface{}) interface{}
+	LevelStringer         func(logrus.Level) string
 
 	// from fluent.Config
 	// see https://github.com/fluent/fluent-logger-golang/blob/master/fluent/fluent.go

--- a/fluent.go
+++ b/fluent.go
@@ -177,7 +177,7 @@ func (hook *FluentHook) Fire(entry *logrus.Entry) error {
 		data[k] = v
 	}
 
-	setLevelString(hook.levelStringer,entry, data)
+	setLevelString(hook.levelStringer, entry, data)
 	tag := hook.getTagAndDel(entry, data)
 	if tag != entry.Message {
 		hook.setMessage(entry, data)

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -130,17 +130,17 @@ func TestLevelStringer(t *testing.T) {
 		return "Hooked " + level.String()
 	}
 
-	expected :="Hooked error"
-	conf := Config{LevelStringer:altStringer}
+	expected := "Hooked error"
+	conf := Config{LevelStringer: altStringer}
 	fields := logrus.Fields{
 		"value": fieldValue,
 	}
 	assertFunc := func(actual string) {
-		if ! strings.Contains(actual,expected) {
-			t.Errorf("actual %v should contain %v",actual,expected)
+		if !strings.Contains(actual, expected) {
+			t.Errorf("actual %v should contain %v", actual, expected)
 		}
 	}
-	assertLogMessageWithConfig(t,conf,fields,"test message",assertFunc)
+	assertLogMessageWithConfig(t, conf, fields, "test message", assertFunc)
 
 }
 

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -125,6 +125,25 @@ func TestLevels(t *testing.T) {
 	}
 }
 
+func TestLevelStringer(t *testing.T) {
+	altStringer := func(level logrus.Level) string {
+		return "Hooked " + level.String()
+	}
+
+	expected :="Hooked error"
+	conf := Config{LevelStringer:altStringer}
+	fields := logrus.Fields{
+		"value": fieldValue,
+	}
+	assertFunc := func(actual string) {
+		if ! strings.Contains(actual,expected) {
+			t.Errorf("actual %v should contain %v",actual,expected)
+		}
+	}
+	assertLogMessageWithConfig(t,conf,fields,"test message",assertFunc)
+
+}
+
 func TestSetLevels(t *testing.T) {
 	hook := FluentHook{}
 


### PR DESCRIPTION
Java loggers (default, logback) are using capital letters when stringifying log levels. This PR allows customizing how logrus.Level are stringified through fluentd so that when Java and Golang services logs are aggregated they are represented the same way.