### PR TITLE
Fixed bug that some default values of Config doesn't work

### DIFF
--- a/fluent.go
+++ b/fluent.go
@@ -67,9 +67,11 @@ func NewWithConfig(conf Config) (*FluentHook, error) {
 	}
 
 	hook := &FluentHook{
-		Fluent: fd,
-		conf:   conf,
-		levels: conf.LogLevels,
+		Fluent:       fd,
+		conf:         conf,
+		levels:       conf.LogLevels,
+		ignoreFields: make(map[string]struct{}),
+		filters:      make(map[string]func(interface{}) interface{}),
 	}
 	// set default values
 	if len(hook.levels) == 0 {
@@ -82,12 +84,13 @@ func NewWithConfig(conf Config) (*FluentHook, error) {
 	if conf.DefaultMessageField != "" {
 		hook.messageField = conf.DefaultMessageField
 	}
-	if hook.ignoreFields == nil {
-		hook.ignoreFields = make(map[string]struct{})
+	for k, v := range conf.DefaultIgnoreFields {
+		hook.ignoreFields[k] = v
 	}
-	if hook.filters == nil {
-		hook.filters = make(map[string]func(interface{}) interface{})
+	for k, v := range conf.DefaultFilters {
+		hook.filters[k] = v
 	}
+
 	return hook, nil
 }
 

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -66,7 +66,7 @@ func TestNewWithConfig(t *testing.T) {
 		Host:                testHOST,
 		Port:                port,
 		DefaultMessageField: "DefaultMessageField",
-		DefaultIgnoreFields: map[string]struct{}{"ignored": struct{}{}},
+		DefaultIgnoreFields: map[string]struct{}{"ignored": {}},
 		DefaultFilters: map[string]func(interface{}) interface{}{
 			"filtered": func(x interface{}) interface{} {
 				return x

--- a/fluent_test.go
+++ b/fluent_test.go
@@ -66,6 +66,12 @@ func TestNewWithConfig(t *testing.T) {
 		Host:                testHOST,
 		Port:                port,
 		DefaultMessageField: "DefaultMessageField",
+		DefaultIgnoreFields: map[string]struct{}{"ignored": struct{}{}},
+		DefaultFilters: map[string]func(interface{}) interface{}{
+			"filtered": func(x interface{}) interface{} {
+				return x
+			},
+		},
 	}
 	hook, err := NewWithConfig(conf)
 	switch {
@@ -83,6 +89,10 @@ func TestNewWithConfig(t *testing.T) {
 		t.Errorf("hook.Fluent should not be nil")
 	case hook.messageField != "DefaultMessageField":
 		t.Errorf("hook.messageField should be DefaultMessageField")
+	case len(hook.ignoreFields) != len(conf.DefaultIgnoreFields):
+		t.Errorf("hook.ignoreFields should be same as conf.DefaultIgnoreFields")
+	case len(hook.filters) != len(conf.DefaultFilters):
+		t.Errorf("hook.filters should be same as conf.DefaultFilters")
 	}
 }
 


### PR DESCRIPTION
The values of Config.defaultIgnoreFields and Config.defaultFilters wasn't applying into FluentHook.
In this PR, Fixed this problem and added simple tests about this.